### PR TITLE
Add seL4 setup helper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+# Ignore build directories and manifest checkouts
+seL4-project/
+*.pyc
+__pycache__/

--- a/README.md
+++ b/README.md
@@ -1,2 +1,28 @@
 # codex_sel4_hypervisor
-Create PoC for running RTOS on SEL4
+
+This repository contains helper scripts and notes for bootstrapping a simple
+seL4 + CAmkES build on x86_64.
+
+The goal is to provide a starting point for experimenting with RTOS workloads
+on the seL4 microkernel.
+
+## Getting Started
+
+The `setup_camkes_x86.sh` script downloads the official `camkes-manifest` using
+the `repo` tool and configures an x86_64 build directory. It assumes you have
+installed the required dependencies (git, repo, build-essential, python3,
+cmake, ninja-build, etc.).
+
+Run the following to fetch sources and build the example:
+
+```bash
+./setup_camkes_x86.sh
+```
+
+The script creates a `seL4-project/` folder containing the manifest checkout.
+The resulting build artifacts are placed in `seL4-project/build/`.
+
+## License
+
+This project is released under the MIT License. See the [LICENSE](LICENSE) file
+for details.

--- a/setup_camkes_x86.sh
+++ b/setup_camkes_x86.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Simple helper script to fetch the CAmkES sources and build seL4 for x86_64.
+# Requires: repo, git, python3, cmake, ninja-build, etc.
+set -e
+
+# Directory where the manifest will be checked out
+PROJECT_DIR="seL4-project"
+
+if [ ! -d "$PROJECT_DIR" ]; then
+    mkdir "$PROJECT_DIR"
+fi
+cd "$PROJECT_DIR"
+
+# Initialize the CAmkES manifest if not already done
+if [ ! -d ".repo" ]; then
+    repo init -u https://github.com/seL4/camkes-manifest.git
+fi
+
+repo sync
+
+# Set up build directory
+BUILD_DIR="build"
+mkdir -p "$BUILD_DIR"
+cd "$BUILD_DIR"
+
+# Configure for x86_64
+../init-build.sh -DPLATFORM=x86_64 "$@"
+
+# Build the image
+ninja


### PR DESCRIPTION
## Summary
- expand README with setup instructions
- add a shell script to fetch and build the CAmkES manifest for x86_64
- ignore build artifacts and downloaded sources

## Testing
- `shellcheck setup_camkes_x86.sh` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68468bb91c3c832cb164f8770833e0ff